### PR TITLE
refactor: apply static analysis to olcs-auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laminas/laminas-session": "^2.8.1",
         "laminas/laminas-stdlib": "^3.0.0",
         "laminas/laminas-view": "^2.11",
-        "lm-commons/lmc-rbac-mvc": "^3.3",
+        "lm-commons/lmc-rbac-mvc": "^3.3.1",
         "psr/container": "^1.1|^2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "bamarni/composer-bin-plugin": "^1.8",
         "johnkary/phpunit-speedtrap": "^4.0",
         "mockery/mockery": "^1.6",
-        "olcs/olcs-common": "^6.0",
+        "olcs/olcs-common": "^6.7",
         "olcs/olcs-transfer": "^6.0",
         "phpunit/phpunit": "^9.6"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,9 @@
 parameters:
-  level: 1
+  level: 5
   paths:
     - src
-    - test
+  excludePaths:
+    - vendor
+  ignoreErrors:
+    - message: '#^Return type \(Laminas\\Http\\Response\) of method Dvsa\\Olcs\\Auth\\Controller\\LogoutController\:\:indexAction\(\) should be compatible with return type \(Laminas\\View\\Model\\ViewModel\) of method Laminas\\Mvc\\Controller\\AbstractActionController\:\:indexAction\(\)$#'
+      path: %currentWorkingDirectory%/src/Controller/LogoutController.php

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-  errorLevel="8"
+  errorLevel="3"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="https://getpsalm.org/schema/config"
   xsi:schemaLocation="https://getpsalm.org/schema/config vendor-bin/psalm/vendor/vimeo/psalm/config.xsd"

--- a/src/Container/AuthChallengeContainer.php
+++ b/src/Container/AuthChallengeContainer.php
@@ -7,9 +7,13 @@ use Laminas\Session\Container;
 class AuthChallengeContainer extends Container
 {
     protected const CONTAINER_NAME = 'authChallenge';
+
     protected const KEY_CHALLENGE_NAME = 'challengeName';
+
     protected const KEY_CHALLENGE_SESSION = 'challengeSession';
+
     protected const KEY_CHALLENGE_IDENTITY = 'challengeIdentity';
+
     public const CHALLENEGE_NEW_PASWORD_REQUIRED = 'NEW_PASSWORD_REQUIRED';
 
     public function __construct()
@@ -17,45 +21,28 @@ class AuthChallengeContainer extends Container
         parent::__construct(static::CONTAINER_NAME);
     }
 
-    /**
-     * @return string
-     */
     public function getChallengeSession(): string
     {
         return $this->offsetGet(static::KEY_CHALLENGE_SESSION);
     }
 
-    /**
-     * @param string $challengeSession
-     * @return AuthChallengeContainer
-     */
     public function setChallengeSession(string $challengeSession): AuthChallengeContainer
     {
         $this->offsetSet(static::KEY_CHALLENGE_SESSION, $challengeSession);
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getChallengeName(): string
     {
         return $this->offsetGet(static::KEY_CHALLENGE_NAME);
     }
 
-    /**
-     * @param string $challengeName
-     * @return AuthChallengeContainer
-     */
     public function setChallengeName(string $challengeName): AuthChallengeContainer
     {
         $this->offsetSet(static::KEY_CHALLENGE_NAME, $challengeName);
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getChallengedIdentity(): string
     {
         return $this->offsetGet(static::KEY_CHALLENGE_IDENTITY);
@@ -63,7 +50,6 @@ class AuthChallengeContainer extends Container
 
     /**
      * @param string $challengedIdentity :
-     * @return AuthChallengeContainer
      */
     public function setChallengedIdentity(string $challengedIdentity): AuthChallengeContainer
     {
@@ -71,9 +57,6 @@ class AuthChallengeContainer extends Container
         return $this;
     }
 
-    /**
-     * @return void
-     */
     public function clear(): void
     {
         $this->exchangeArray([]);

--- a/src/Controller/ForgotPasswordController.php
+++ b/src/Controller/ForgotPasswordController.php
@@ -15,12 +15,9 @@ use Dvsa\Olcs\Auth\Service\Auth\PasswordService;
 class ForgotPasswordController extends AbstractController
 {
     private FormHelperService $formHelperService;
+
     private PasswordService $passwordService;
 
-    /**
-     * @param FormHelperService $formHelperService
-     * @param PasswordService $passwordService
-     */
     public function __construct(
         FormHelperService $formHelperService,
         PasswordService $passwordService
@@ -33,12 +30,15 @@ class ForgotPasswordController extends AbstractController
      * Forgot password page
      *
      * @return ViewModel|\Laminas\Http\Response
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
      */
     public function indexAction()
     {
         if ($this->isButtonPressed('cancel')) {
             return $this->redirect()->toRoute('auth/login/GET');
         }
+
         /** @var Request $request */
         $request = $this->getRequest();
 
@@ -52,9 +52,11 @@ class ForgotPasswordController extends AbstractController
         }
 
         try {
+
+            /** @var array $formData */
             $formData = $form->getData();
             $result = $this->passwordService->forgotPassword($formData['username']);
-        } catch (Cqrs\Exception $e) {
+        } catch (Cqrs\Exception $exception) {
             return $this->renderFormView($form, true, 'unknown-error');
         }
 

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -4,25 +4,12 @@ namespace Dvsa\Olcs\Auth\Controller;
 
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Session\Container;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Http\Response;
-use Laminas\Http\Request;
 
 /**
  * Class LogoutController
  */
 class LogoutController extends AbstractActionController
 {
-    /**
-     * @var RequestInterface
-     */
-    private $requestService;
-
-    /**
-     * @var Response
-     */
-    private $responseService;
-
     /**
      * @var bool
      */
@@ -41,20 +28,14 @@ class LogoutController extends AbstractActionController
     /**
      * LogoutController constructor.
      *
-     * @param Request       $requestService       Laminas request service
-     * @param Response      $responseService      Laminas response service
      * @param bool          $isSelfServe          Is the current user selfserve?
      * @param string        $selfServeRedirectUrl URL to redirect self serve user
      */
     public function __construct(
-        Request $requestService,
-        Response $responseService,
         $isSelfServe,
         $selfServeRedirectUrl,
         Container $session
     ) {
-        $this->requestService = $requestService;
-        $this->responseService = $responseService;
         $this->isSelfServe = $isSelfServe;
         $this->selfServeRedirectUrl = $selfServeRedirectUrl;
         $this->session = $session;
@@ -64,6 +45,8 @@ class LogoutController extends AbstractActionController
      * Logout the user, and redirect to index or Gov site
      *
      * @return \Laminas\Http\Response
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
      */
     public function indexAction()
     {
@@ -75,6 +58,7 @@ class LogoutController extends AbstractActionController
                 $this->selfServeRedirectUrl
             );
         }
+
         return $this->redirect()->toRoute('auth/login/GET');
     }
 }

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -4,6 +4,7 @@ namespace Dvsa\Olcs\Auth\Controller;
 
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
+use Laminas\Form\Form;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use Dvsa\Olcs\Auth\Form\ResetPasswordForm;
@@ -11,26 +12,12 @@ use Dvsa\Olcs\Auth\Service\Auth\PasswordService;
 
 class ResetPasswordController extends AbstractActionController
 {
-    /**
-     * @var FormHelperService
-     */
     private FormHelperService $formHelperService;
 
-    /**
-     * @var FlashMessengerHelperService
-     */
     private FlashMessengerHelperService $flashMessenger;
 
-    /**
-     * @var PasswordService
-     */
     private PasswordService $passwordService;
 
-    /**
-     * @param FormHelperService $formHelperService
-     * @param FlashMessengerHelperService $flashMessenger
-     * @param PasswordService $passwordService
-     */
     public function __construct(
         FormHelperService $formHelperService,
         FlashMessengerHelperService $flashMessenger,
@@ -45,11 +32,15 @@ class ResetPasswordController extends AbstractActionController
      * Reset password
      *
      * @return \Laminas\Http\Response|ViewModel
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
      */
     public function indexAction()
     {
+        /** @var \Laminas\Http\Request $request */
         $request = $this->getRequest();
 
+        /** @var Form $form */
         $form = $this->formHelperService->createFormWithRequest(ResetPasswordForm::class, $request);
 
         if ($request->isPost() === false) {
@@ -62,6 +53,7 @@ class ResetPasswordController extends AbstractActionController
             return $this->renderView($form);
         }
 
+        /** @var array $data */
         $data = $form->getData();
 
         $confirmationId = $this->params()->fromQuery('confirmationId');

--- a/src/Controller/ValidateController.php
+++ b/src/Controller/ValidateController.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Dvsa\Olcs\Auth\Controller;
 
-use Common\Rbac\PidIdentityProvider;
+use Common\Rbac\JWTIdentityProvider;
 use Dvsa\Olcs\Auth\ControllerFactory\ValidateControllerFactory;
-use Dvsa\Olcs\Auth\Service\Auth\CookieService;
-use Dvsa\Olcs\Auth\Service\Auth\ValidateService;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
 use LmcRbacMvc\Identity\IdentityProviderInterface;
@@ -31,7 +29,9 @@ class ValidateController extends AbstractActionController
      */
     public function indexAction(): JsonModel
     {
-        $respBody = $this->identityProvider->validateToken();
+        /** @var JWTIdentityProvider $identityProvider */
+        $identityProvider = $this->identityProvider;
+        $respBody = $identityProvider->validateToken();
         return new JsonModel($respBody);
     }
 }

--- a/src/ControllerFactory/ChangePasswordControllerFactory.php
+++ b/src/ControllerFactory/ChangePasswordControllerFactory.php
@@ -9,10 +9,8 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 class ChangePasswordControllerFactory implements FactoryInterface
 {
     /**
-     * @param ContainerInterface $container
      * @param $requestedName
      * @param array|null $options
-     * @return ChangePasswordController
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ChangePasswordController
     {
@@ -21,12 +19,14 @@ class ChangePasswordControllerFactory implements FactoryInterface
         $formHelper = $container->get('Helper\Form');
         $flashMessenger = $container->get('Helper\FlashMessenger');
         $commandSender = $container->get('CommandSender');
+        $redirectPlugin = $container->get('ControllerPluginManager')->get('redirect');
 
         return new ChangePasswordController(
             $formHelper,
             $flashMessenger,
             $config,
-            $commandSender
+            $commandSender,
+            $redirectPlugin
         );
     }
 }

--- a/src/ControllerFactory/ExpiredPasswordControllerFactory.php
+++ b/src/ControllerFactory/ExpiredPasswordControllerFactory.php
@@ -18,10 +18,8 @@ use Psr\Container\NotFoundExceptionInterface as NotFoundExceptionInterfaceAlias;
 class ExpiredPasswordControllerFactory implements FactoryInterface
 {
     /**
-     * @param ContainerInterface $container
      * @param $requestedName
      * @param array|null $options
-     * @return ExpiredPasswordController
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterfaceAlias
      */

--- a/src/ControllerFactory/ForgotPasswordControllerFactory.php
+++ b/src/ControllerFactory/ForgotPasswordControllerFactory.php
@@ -13,10 +13,8 @@ use Psr\Container\NotFoundExceptionInterface;
 class ForgotPasswordControllerFactory implements FactoryInterface
 {
     /**
-     * @param ContainerInterface $container
      * @param $requestedName
      * @param array|null $options
-     * @return ForgotPasswordController
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */

--- a/src/ControllerFactory/LogoutControllerFactory.php
+++ b/src/ControllerFactory/LogoutControllerFactory.php
@@ -22,18 +22,14 @@ class LogoutControllerFactory implements FactoryInterface
         /** @var Request $requestService */
         $requestService = $container->get('Request');
 
-        /** @var Response $responseService */
-        $responseService = new Response();
-
         $sessionName = $config['auth']['session_name'] ?? '';
         if (empty($sessionName)) {
             throw new RunTimeException("Missing auth.session_name from config");
         }
+
         $session = new Container($sessionName);
 
         return new LogoutController(
-            $requestService,
-            $responseService,
             $this->isSelfServeUser($requestService),
             $this->getSelfServeLogoutUrl($config),
             $session

--- a/src/ControllerFactory/ResetPasswordControllerFactory.php
+++ b/src/ControllerFactory/ResetPasswordControllerFactory.php
@@ -12,10 +12,8 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 class ResetPasswordControllerFactory implements FactoryInterface
 {
     /**
-     * @param ContainerInterface $container
      * @param $requestedName
      * @param array|null $options
-     * @return ResetPasswordController
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ResetPasswordController
     {

--- a/src/Form/ChangePasswordForm.php
+++ b/src/Form/ChangePasswordForm.php
@@ -20,7 +20,7 @@ class ChangePasswordForm
      * @Form\Filter({"name": "Laminas\Filter\StringTrim"})
      * @Form\Type("Password")
      */
-    public $oldPassword = null;
+    public $oldPassword;
 
     /**
      * @Form\Options({
@@ -33,7 +33,7 @@ class ChangePasswordForm
      * @Form\Validator({"name":"Common\Form\Elements\Validators\PasswordConfirm","options":{"token":"confirmPassword"}})
      * @Form\Type("Password")
      */
-    public $newPassword = null;
+    public $newPassword;
 
     /**
      * @Form\Options({
@@ -45,7 +45,7 @@ class ChangePasswordForm
      * @Form\Filter({"name": "Laminas\Filter\StringTrim"})
      * @Form\Type("Password")
      */
-    public $confirmPassword = null;
+    public $confirmPassword;
 
     /**
      * @Form\Attributes({
@@ -55,7 +55,7 @@ class ChangePasswordForm
      * })
      * @Form\Type("Submit")
      */
-    public $submit = null;
+    public $submit;
 
     /**
      * @Form\Attributes({
@@ -69,5 +69,5 @@ class ChangePasswordForm
      * })
      * @Form\Type("\Common\Form\Elements\InputFilters\ActionButton")
      */
-    public $cancel = null;
+    public $cancel;
 }

--- a/src/Form/ForgotPasswordForm.php
+++ b/src/Form/ForgotPasswordForm.php
@@ -21,7 +21,7 @@ class ForgotPasswordForm
      * @Form\Validator({"name":"Dvsa\Olcs\Transfer\Validators\Username"})
      * @Form\Type("Text")
      */
-    public $username = null;
+    public $username;
 
     /**
      * @Form\Attributes({
@@ -31,7 +31,7 @@ class ForgotPasswordForm
      * })
      * @Form\Type("Submit")
      */
-    public $submit = null;
+    public $submit;
 
     /**
      * @Form\Attributes({
@@ -45,5 +45,5 @@ class ForgotPasswordForm
      * })
      * @Form\Type("\Common\Form\Elements\InputFilters\ActionButton")
      */
-    public $cancel = null;
+    public $cancel;
 }

--- a/src/Form/LoginForm.php
+++ b/src/Form/LoginForm.php
@@ -26,7 +26,7 @@ class LoginForm
      * @Form\Validator({"name":"Dvsa\Olcs\Transfer\Validators\Username"})
      * @Form\Type("Text")
      */
-    public $username = null;
+    public $username;
 
     /**
      * @Form\Options({
@@ -42,7 +42,7 @@ class LoginForm
      * @Form\Filter({"name": "Laminas\Filter\StringTrim"})
      * @Form\Type("Password")
      */
-    public $password = null;
+    public $password;
 
     /**
      * @Form\Attributes({
@@ -52,5 +52,5 @@ class LoginForm
      * })
      * @Form\Type("Submit")
      */
-    public $submit = null;
+    public $submit;
 }

--- a/src/Form/ResetPasswordForm.php
+++ b/src/Form/ResetPasswordForm.php
@@ -28,7 +28,7 @@ class ResetPasswordForm
      * })
      * @Form\Type("Password")
      */
-    public $newPassword = null;
+    public $newPassword;
 
     /**
      * @Form\Options({
@@ -41,7 +41,7 @@ class ResetPasswordForm
      * @Form\Validator({"name":"Laminas\Validator\StringLength","options":{"min":12}})
      * @Form\Type("Password")
      */
-    public $confirmPassword = null;
+    public $confirmPassword;
 
     /**
      * @Form\Attributes({
@@ -51,5 +51,5 @@ class ResetPasswordForm
      * })
      * @Form\Type("Submit")
      */
-    public $submit = null;
+    public $submit;
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -17,8 +17,10 @@ class Module
 {
     /**
      * Get module config
+     *
+     * @return array
      */
-    public function getConfig()
+    public function getConfig(): array
     {
         return include __DIR__ . '/../config/module.config.php';
     }

--- a/src/Service/Auth/Callback/Request.php
+++ b/src/Service/Auth/Callback/Request.php
@@ -10,6 +10,7 @@ namespace Dvsa\Olcs\Auth\Service\Auth\Callback;
 class Request
 {
     public const STAGE_AUTHENTICATE = 'LDAP1';
+
     public const STAGE_EXPIRED_PASSWORD = 'LDAP2';
 
     /**
@@ -47,10 +48,8 @@ class Request
      * Add callback
      *
      * @param CallbackInterface $callback Callback
-     *
-     * @return void
      */
-    public function addCallback(CallbackInterface $callback)
+    public function addCallback(CallbackInterface $callback): void
     {
         $this->callbacks[] = $callback;
     }

--- a/src/Service/Auth/PasswordService.php
+++ b/src/Service/Auth/PasswordService.php
@@ -11,7 +11,9 @@ use Dvsa\Olcs\Transfer\Command\CommandInterface;
 class PasswordService
 {
     private CommandSender $commandSender;
+
     private ResponseDecoderService $responseDecoder;
+
     private string $realm;
 
     public function __construct(CommandSender $commandSender, ResponseDecoderService $responseDecoder, string $realm)
@@ -26,8 +28,6 @@ class PasswordService
      *
      * @param string  $oldPassword Old password
      * @param string  $newPassword New password
-     *
-     * @return array
      */
     public function updatePassword($oldPassword, $newPassword): array
     {
@@ -48,8 +48,6 @@ class PasswordService
      * @param string $confirmationId Confirmation id
      * @param string $tokenId        Token id
      * @param string $newPassword    New password
-     *
-     * @return array
      */
     public function resetPassword($username, $confirmationId, $tokenId, $newPassword): array
     {
@@ -69,8 +67,6 @@ class PasswordService
      * Forgot password
      *
      * @param string $username Username
-     *
-     * @return array
      */
     public function forgotPassword($username): array
     {
@@ -83,11 +79,7 @@ class PasswordService
         return $this->response($command);
     }
 
-    /**
-     * @param CommandInterface $command
-     *
-     * @return array
-     */
+
     private function response(CommandInterface $command): array
     {
         return $this->responseDecoder->decode(

--- a/src/Service/Auth/PasswordServiceFactory.php
+++ b/src/Service/Auth/PasswordServiceFactory.php
@@ -13,11 +13,8 @@ class PasswordServiceFactory implements FactoryInterface
     public const MSG_MISSING_REALM = 'Auth config is missing the realm';
 
     /**
-     * @param ContainerInterface $container
      * @param $requestedName
      * @param array|null $options
-     *
-     * @return PasswordService
      * @throws RuntimeException
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): PasswordService

--- a/test/Controller/ChangePasswordControllerTest.php
+++ b/test/Controller/ChangePasswordControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Dvsa\OlcsTest\Auth\Controller;
 
+use Common\Controller\Plugin\Redirect;
 use Common\Rbac\JWTIdentityProvider;
 use Common\Service\Cqrs\Command\CommandSender;
 use Common\Service\Cqrs\Response;
@@ -9,12 +10,10 @@ use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Dvsa\Olcs\Auth\Controller\ChangePasswordController;
 use Dvsa\Olcs\Auth\Form\ChangePasswordForm;
-use Dvsa\Olcs\Auth\Service\Auth\ChangePasswordService;
 use Dvsa\Olcs\Transfer\Result\Auth\ChangePasswordResult;
 use Laminas\Form\Form;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Http\Response as HttpResponse;
-use Laminas\Mvc\Controller\Plugin\Redirect;
 use Laminas\Mvc\Controller\PluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Model\ViewModel;
@@ -45,7 +44,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
 
     private array $config;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->formHelper = m::mock(FormHelperService::class);
         $this->flashMessenger = m::mock(FlashMessengerHelperService::class);
@@ -68,11 +67,11 @@ class ChangePasswordControllerTest extends MockeryTestCase
         $pm = m::mock(PluginManager::class)->makePartial();
         $pm->setService('redirect', $this->redirect);
 
-        $this->sut = new ChangePasswordController($this->formHelper, $this->flashMessenger, $this->config, $this->commandSender);
+        $this->sut = new ChangePasswordController($this->formHelper, $this->flashMessenger, $this->config, $this->commandSender, $this->redirect);
         $this->sut->setPluginManager($pm);
     }
 
-    public function testIndexActionForGet()
+    public function testIndexActionForGet(): void
     {
         $form = m::mock(Form::class);
 
@@ -89,7 +88,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
         $this->assertEquals('auth/change-password', $result->getTemplate());
     }
 
-    public function testIndexActionForPostWithInvalidData()
+    public function testIndexActionForPostWithInvalidData(): void
     {
         $post = [];
 
@@ -111,7 +110,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
         $this->assertEquals('auth/change-password', $result->getTemplate());
     }
 
-    public function testIndexActionForPostWithCancel()
+    public function testIndexActionForPostWithCancel(): void
     {
         $post = [
             'cancel' => '',
@@ -132,7 +131,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
         $this->assertEquals('REDIRECT', $this->sut->indexAction());
     }
 
-    public function testIndexActionForPostWithValidDataSuccess()
+    public function testIndexActionForPostWithValidDataSuccess(): void
     {
         $post = [
             'oldPassword' => 'old-password',
@@ -154,6 +153,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
 
         $response = new HttpResponse();
         $response->setStatusCode(HttpResponse::STATUS_CODE_200);
+
         $result = new Response($response);
         $result->setResult([
             'flags' => [
@@ -172,7 +172,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
         $this->assertEquals('REDIRECT', $this->sut->indexAction());
     }
 
-    public function testIndexActionForPostWithValidDataFailure()
+    public function testIndexActionForPostWithValidDataFailure(): void
     {
         $post = [
             'oldPassword' => 'old-password',
@@ -194,6 +194,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
 
         $response = new HttpResponse();
         $response->setStatusCode(HttpResponse::STATUS_CODE_200);
+
         $result = new Response($response);
         $result->setResult([
             'flags' => [
@@ -212,7 +213,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
         $this->assertEquals('error message', $result->getVariable('failureReason'));
     }
 
-    public function testIndexActionForPostWithValidDataBadResult()
+    public function testIndexActionForPostWithValidDataBadResult(): void
     {
         $post = [
             'oldPassword' => 'old-password',
@@ -234,6 +235,7 @@ class ChangePasswordControllerTest extends MockeryTestCase
 
         $response = new HttpResponse();
         $response->setStatusCode(HttpResponse::STATUS_CODE_500);
+
         $result = new Response($response);
 
         $this->commandSender->shouldReceive('send')->andReturn($result);

--- a/test/Controller/ExpiredPasswordControllerTest.php
+++ b/test/Controller/ExpiredPasswordControllerTest.php
@@ -11,8 +11,6 @@ use Common\Service\Helper\FormHelperService;
 use Dvsa\Olcs\Auth\Container\AuthChallengeContainer;
 use Dvsa\Olcs\Auth\Controller\ExpiredPasswordController;
 use Dvsa\Olcs\Auth\Form\ChangePasswordForm;
-use Dvsa\Olcs\Auth\Service\Auth\ExpiredPasswordService;
-use Dvsa\Olcs\Auth\Service\Auth\LoginService;
 use Dvsa\Olcs\Transfer\Result\Auth\ChangeExpiredPasswordResult;
 use Laminas\Authentication\Storage\Session;
 use Laminas\Form\ElementInterface;
@@ -20,7 +18,6 @@ use Laminas\Form\Form;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\Mvc\Controller\Plugin\Layout;
 use Laminas\Mvc\Controller\Plugin\Redirect;
-use Laminas\Mvc\Controller\Plugin\Url;
 use Laminas\Mvc\Controller\PluginManager;
 use Laminas\Stdlib\Parameters;
 use Laminas\View\Model\ViewModel;
@@ -37,6 +34,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
      * @var ExpiredPasswordController
      */
     private $sut;
+
     /**
      * @var mixed|m\LegacyMockInterface|m\MockInterface
      */
@@ -68,17 +66,16 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
     private $sessionContainer;
 
     private $layout;
-    private $url;
+
     private $pm;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->formHelper = m::mock(FormHelperService::class);
         $this->commandSender = m::mock(CommandSender::class)->makePartial();
         $this->flashMessenger = m::mock(FlashMessengerHelperService::class);
         $this->redirect = m::mock(Redirect::class)->makePartial();
         $this->layout = m::mock(Layout::class)->makePartial();
-        $this->url = m::mock(Url::class)->makePartial();
         $this->authChallengeContainer = m::mock(AuthChallengeContainer::class);
         $this->sessionContainer = m::mock(Session::class);
 
@@ -95,7 +92,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->sut->setPluginManager($this->pm);
     }
 
-    public function testIndexActionForGet()
+    public function testIndexActionForGet(): void
     {
         $this->pm->expects('get')->with('layout', null)->andReturn($this->layout);
         $this->layout->expects('__invoke')->with('auth/layout');
@@ -124,7 +121,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->assertEquals('auth/expired-password', $result->getTemplate());
     }
 
-    public function testIndexActionForInvalidPostRequest()
+    public function testIndexActionForInvalidPostRequest(): void
     {
         $this->pm->expects('get')->with('layout', null)->andReturn($this->layout);
         $this->layout->expects('__invoke')->with('auth/layout');
@@ -150,7 +147,8 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->assertInstanceOf(ViewModel::class, $result);
         $this->assertEquals('auth/expired-password', $result->getTemplate());
     }
-    public function testIndexActionForPostWithInvalidDataOnForm()
+
+    public function testIndexActionForPostWithInvalidDataOnForm(): void
     {
         $post = [];
 
@@ -181,7 +179,8 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->assertInstanceOf(ViewModel::class, $result);
         $this->assertEquals('auth/expired-password', $result->getTemplate());
     }
-    public function testIndexActionForPostWithValidDataSuccess()
+
+    public function testIndexActionForPostWithValidDataSuccess(): void
     {
         $post = [
             'newPassword' => 'new-password',
@@ -244,7 +243,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->assertEquals('REDIRECT', $this->sut->indexAction());
     }
 
-    public function testIndexActionForPostWithValidDataWrongChallenge()
+    public function testIndexActionForPostWithValidDataWrongChallenge(): void
     {
         $post = [
             'newPassword' => 'new-password',
@@ -279,7 +278,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->sut->indexAction();
     }
 
-    public function testIndexActionForPostWithValidDataResultNotOk()
+    public function testIndexActionForPostWithValidDataResultNotOk(): void
     {
         $post = [
             'newPassword' => 'new-password',
@@ -330,7 +329,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
      *
      * @dataProvider errorMessagesDataProvider
      */
-    public function testIndexActionForPostWithValidDataNewPasswordInvalid($errorMessage)
+    public function testIndexActionForPostWithValidDataNewPasswordInvalid($errorMessage): void
     {
         $post = [
             'newPassword' => 'new-password',
@@ -408,7 +407,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         ];
     }
 
-    public function testIndexActionForPostWithValidDataNotAuthorizedFailure()
+    public function testIndexActionForPostWithValidDataNotAuthorizedFailure(): void
     {
         $post = [
             'newPassword' => 'new-password',
@@ -477,7 +476,7 @@ class ExpiredPasswordControllerTest extends MockeryTestCase
         $this->assertEquals('REDIRECT', $this->sut->indexAction());
     }
 
-    public function testIndexActionForPostWithValidDataInvalidResponse()
+    public function testIndexActionForPostWithValidDataInvalidResponse(): void
     {
         $post = [
             'newPassword' => 'new-password',

--- a/test/Controller/LogoutControllerTest.php
+++ b/test/Controller/LogoutControllerTest.php
@@ -3,8 +3,6 @@
 namespace Dvsa\OlcsTest\Auth\Controller;
 
 use Dvsa\Olcs\Auth\Controller\LogoutController;
-use Dvsa\Olcs\Auth\Service\Auth\CookieService;
-use Dvsa\Olcs\Auth\Service\Auth\LogoutService;
 use Laminas\Http\Request;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\Plugin\Redirect;
@@ -24,26 +22,20 @@ class LogoutControllerTest extends MockeryTestCase
      * @var Redirect
      */
     private $redirect;
+
     /**
      * @var Request|(Request&m\LegacyMockInterface)|(Request&m\MockInterface)|m\LegacyMockInterface|m\MockInterface
      */
     private $request;
+
     /**
      * @var Response|(Response&m\LegacyMockInterface)|(Response&m\MockInterface)|m\LegacyMockInterface|m\MockInterface
      */
     private $response;
 
-    public function setUp(): void
-    {
-        $this->request = m::mock(Request::class);
-        $this->response = m::mock(Response::class);
-    }
-
-    public function testIsRealmSelfServeThenRedirectToGovSite()
+    public function testIsRealmSelfServeThenRedirectToGovSite(): void
     {
         $controller = new LogoutController(
-            $this->request,
-            $this->response,
             true,
             self::REDIRECT_URL,
             $this->createMock(Container::class)
@@ -62,11 +54,9 @@ class LogoutControllerTest extends MockeryTestCase
         $this->assertEquals('REDIRECT', $controller->indexAction());
     }
 
-    public function testIsRealmNotSelfServeThenRedirectToLogin()
+    public function testIsRealmNotSelfServeThenRedirectToLogin(): void
     {
         $controller = new LogoutController(
-            $this->request,
-            $this->response,
             false,
             self::REDIRECT_URL,
             $this->createMock(Container::class)

--- a/test/Controller/ValidateControllerTest.php
+++ b/test/Controller/ValidateControllerTest.php
@@ -15,9 +15,6 @@ use LmcRbacMvc\Identity\IdentityProviderInterface;
  */
 class ValidateControllerTest extends MockeryTestCase
 {
-    /** @var  ValidateController */
-    private $sut;
-
     public function testIndexAction(): void
     {
         $returnedArray = ['response' => 'content'];

--- a/test/ControllerFactory/ExpiredPasswordControllerFactoryTest.php
+++ b/test/ControllerFactory/ExpiredPasswordControllerFactoryTest.php
@@ -45,14 +45,14 @@ class ExpiredPasswordControllerFactoryTest extends MockeryTestCase
         $this->setUpSut();
 
         // Assert
-        $this->assertIsCallable([$this->sut, '__invoke']);
+        $this->assertIsCallable(fn(\Psr\Container\ContainerInterface $container, string $requestedName, ?array $options = null): \Dvsa\Olcs\Auth\Controller\ExpiredPasswordController => $this->sut->__invoke($container, $requestedName, $options));
     }
 
     /**
      * @test
      * @depends invokeIsCallable
      */
-    public function invokeReturnsAnInstanceOfExpiredPasswordController()
+    public function invokeReturnsAnInstanceOfExpiredPasswordController(): void
     {
         // Setup
         $this->setUpSut();
@@ -71,12 +71,14 @@ class ExpiredPasswordControllerFactoryTest extends MockeryTestCase
 
     protected function setUpConfig(array $config = []): array
     {
-        if (!$this->serviceManager->has('Config') || !empty($config)) {
-            if (empty($config)) {
-                $config = static::CONFIG_VALID;
+        if (!$this->serviceManager->has('Config') || $config !== []) {
+            if ($config === []) {
+                $config = self::CONFIG_VALID;
             }
+
             $this->serviceManager->setService('Config', $config);
         }
+
         return $this->serviceManager->get('Config');
     }
 

--- a/test/ControllerFactory/LogoutControllerFactoryTest.php
+++ b/test/ControllerFactory/LogoutControllerFactoryTest.php
@@ -15,10 +15,12 @@ use Mockery as m;
 class LogoutControllerFactoryTest extends m\Adapter\Phpunit\MockeryTestCase
 {
     private $container;
+
     private $mockRequest;
+
     private $config;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = m::mock(ContainerInterface::class);
         // Set realm by default, but can be overwritten
@@ -35,11 +37,10 @@ class LogoutControllerFactoryTest extends m\Adapter\Phpunit\MockeryTestCase
 
     /**
      * @param string $realm             Realm name
-     * @param bool   $expectedException Are we expecting an exception?
      *
      * @dataProvider realmDataProvider
      */
-    public function testLogoutControllerFactoryWithRealm($realm)
+    public function testLogoutControllerFactoryWithRealm($realm): void
     {
         // Set realm defined in data provider
         $this->mockRequest->method('getServer')->with('HTTP_X_REALM')->willReturn($realm);
@@ -76,7 +77,7 @@ class LogoutControllerFactoryTest extends m\Adapter\Phpunit\MockeryTestCase
         ];
     }
 
-    public function testNoSelfServeLogoutUrlSpecified()
+    public function testNoSelfServeLogoutUrlSpecified(): void
     {
         $this->expectException(
             \InvalidArgumentException::class

--- a/test/Service/Auth/Callback/ConfirmationCallbackTest.php
+++ b/test/Service/Auth/Callback/ConfirmationCallbackTest.php
@@ -17,7 +17,7 @@ use Dvsa\Olcs\Auth\Service\Auth\Callback\ConfirmationCallback;
  */
 class ConfirmationCallbackTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCallback()
+    public function testCallback(): void
     {
         $sut = new ConfirmationCallback('foo');
         $result = $sut->toArray();

--- a/test/Service/Auth/Callback/NameCallbackTest.php
+++ b/test/Service/Auth/Callback/NameCallbackTest.php
@@ -17,7 +17,7 @@ use Dvsa\Olcs\Auth\Service\Auth\Callback\NameCallback;
  */
 class NameCallbackTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCallback()
+    public function testCallback(): void
     {
         $sut = new NameCallback('Username', 'ID1', 'test');
         $result = $sut->toArray();

--- a/test/Service/Auth/Callback/PasswordCallbackTest.php
+++ b/test/Service/Auth/Callback/PasswordCallbackTest.php
@@ -17,7 +17,7 @@ use Dvsa\Olcs\Auth\Service\Auth\Callback\PasswordCallback;
  */
 class PasswordCallbackTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCallback()
+    public function testCallback(): void
     {
         $sut = new PasswordCallback('UserPassword', 'ID1', 'test');
         $result = $sut->toArray();

--- a/test/Service/Auth/Callback/RequestTest.php
+++ b/test/Service/Auth/Callback/RequestTest.php
@@ -20,7 +20,7 @@ use Dvsa\Olcs\Auth\Service\Auth\Callback\Request;
  */
 class RequestTest extends MockeryTestCase
 {
-    public function testRequest()
+    public function testRequest(): void
     {
         $callback1 = m::mock(CallbackInterface::class);
         $callback1->shouldReceive('toArray')->andReturn(['callback1' => 'stuff']);

--- a/test/Service/Auth/PasswordServiceTest.php
+++ b/test/Service/Auth/PasswordServiceTest.php
@@ -40,7 +40,7 @@ class PasswordServiceTest extends MockeryTestCase
         $cqrsResponse = $this->cqrsResponse($laminasResponse);
 
         $commandSender = m::mock(CommandSender::class);
-        $commandSender->expects('send')->with(m::type(ResetPassword::class))->andReturnUsing(
+        $commandSender->shouldReceive('send')->with(m::type(ResetPassword::class))->andReturnUsing(
             function (ResetPassword $resetPasswordCmd) use ($data, $cqrsResponse) {
                 $this->assertEquals($resetPasswordCmd->getArrayCopy(), $data);
                 return $cqrsResponse;
@@ -67,7 +67,7 @@ class PasswordServiceTest extends MockeryTestCase
         $cqrsResponse = $this->cqrsResponse($laminasResponse);
 
         $commandSender = m::mock(CommandSender::class);
-        $commandSender->expects('send')->with(m::type(ChangePassword::class))->andReturnUsing(
+        $commandSender->shouldReceive('send')->with(m::type(ChangePassword::class))->andReturnUsing(
             function (ChangePassword $changePasswordCmd) use ($data, $cqrsResponse) {
                 $this->assertEquals($changePasswordCmd->getArrayCopy(), $data);
                 return $cqrsResponse;
@@ -93,7 +93,7 @@ class PasswordServiceTest extends MockeryTestCase
         $cqrsResponse = $this->cqrsResponse($laminasResponse);
 
         $commandSender = m::mock(CommandSender::class);
-        $commandSender->expects('send')->with(m::type(ForgotPassword::class))->andReturnUsing(
+        $commandSender->shouldReceive('send')->with(m::type(ForgotPassword::class))->andReturnUsing(
             function (ForgotPassword $changePasswordCmd) use ($data, $cqrsResponse) {
                 $this->assertEquals($changePasswordCmd->getArrayCopy(), $data);
                 return $cqrsResponse;
@@ -108,7 +108,7 @@ class PasswordServiceTest extends MockeryTestCase
     private function cqrsResponse($laminasResponse): m\MockInterface
     {
         $cqrsResponse = m::mock(CqrsResponse::class);
-        $cqrsResponse->expects('getHttpResponse')->withNoArgs()->andReturn($laminasResponse);
+        $cqrsResponse->shouldReceive('getHttpResponse')->withNoArgs()->andReturn($laminasResponse);
 
         return $cqrsResponse;
     }
@@ -116,7 +116,7 @@ class PasswordServiceTest extends MockeryTestCase
     private function responseDecoder($laminasResponse): m\MockInterface
     {
         $responseDecoder = m::mock(ResponseDecoderService::class);
-        $responseDecoder->expects('decode')->with($laminasResponse)->andReturn($this->expectedResponse());
+        $responseDecoder->shouldReceive('decode')->with($laminasResponse)->andReturn($this->expectedResponse());
 
         return $responseDecoder;
     }

--- a/test/Service/Auth/ResponseDecoderServiceTest.php
+++ b/test/Service/Auth/ResponseDecoderServiceTest.php
@@ -21,7 +21,7 @@ use Laminas\Http\Response;
  */
 class ResponseDecoderServiceTest extends MockeryTestCase
 {
-    public function testDecodeFailed()
+    public function testDecodeFailed(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -32,7 +32,7 @@ class ResponseDecoderServiceTest extends MockeryTestCase
         $sut->decode($response);
     }
 
-    public function testDecode()
+    public function testDecode(): void
     {
         $response = new Response();
         $response->setStatusCode(200);


### PR DESCRIPTION
## Description

changes to get rector/phpstan/psalm  passing on OLCS Auth @ lvl 5

Related issue: [VOL-4756](https://dvsa.atlassian.net/browse/VOL-4756)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
