### PR TITLE
fix: expired password journey now redirects correctly VOL-5896

### DIFF
--- a/src/Controller/ExpiredPasswordController.php
+++ b/src/Controller/ExpiredPasswordController.php
@@ -28,7 +28,7 @@ class ExpiredPasswordController extends AbstractActionController
 
     public const MESSAGE_CHALLENGE_NOT_NEW_PASSWORD_REQUIRED = 'Expected challenge name to be NEW_PASSWORD_REQUIRED';
 
-    public const ROUTE_INDEX = 'dashboard';
+    public const ROUTE_INDEX = 'index';
 
     public const ROUTE_LOGIN = 'auth/login/GET';
 


### PR DESCRIPTION
## Description

Users coming from the expired password journey are now redirected through the index controller.

Related issue: [VOL-5896](https://dvsa.atlassian.net/browse/VOL-5896)

